### PR TITLE
Remove cost_price override

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -45,11 +45,5 @@ module Spree
     def mark_down_sale_price
       mark_down.calculate_sale_price(self) unless mark_down.blank?
     end
-
-    def cost_price
-      return self[:cost_price] * (1 - mark_down.amount/100) if self[:cost_price].present? && mark_down.present?
-
-      self[:cost_price]
-    end
   end
 end


### PR DESCRIPTION
cost_price method is overridden even in maisonette.
We could remove it from here to use the `super` method in prepend decorator